### PR TITLE
Use StreamEffectClsid and ModeEffectClsid

### DIFF
--- a/EnableLoudness.ps1
+++ b/EnableLoudness.ps1
@@ -67,6 +67,8 @@ $fxPropertiesImport = @"
 "{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},1"="{62dc1a93-ae24-464c-a43e-452f824c4250}" ;PreMixEffectClsid activates effects
 "{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},2"="{637c490d-eee3-4c0a-973f-371958802da2}" ;PostMixEffectClsid activates effects
 "{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},3"="{5860E1C5-F95C-4a7a-8EC8-8AEF24F379A1}" ;UserInterfaceClsid shows it in ui
+"{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},5"="{62dc1a93-ae24-464c-a43e-452f824c4250}" ;StreamEffectClsid
+"{d04e05a6-594b-4fb6-a80d-01af5eed7d1d},6"="{637c490d-eee3-4c0a-973f-371958802da2}" ;ModeEffectClsid
 "{fc52a749-4be9-4510-896e-966ba6525980},3"=hex:0b,00,00,00,01,00,00,00,ff,ff,00,00 ;enables loudness equalisation
 "{9c00eeed-edce-4cd8-ae08-cb05e8ef57a0},3"=hex:03,00,00,00,01,00,00,00,$releaseTimeStr,00,00,00 ;equalisation release time 2 to 7
 "@

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Or if you want to set the fastest possible time until sound level gets adjusted 
 1. search for all active playback devices by name in registry
 1. imports audio enhancement settings
     - PreMixEffectClsid and PostMixEffectClsid
+    - StreamEffectClsid and ModeEffectClsid
     - Enhancement Tab UI defnition
     - loudness equalisation flag
     - release time value


### PR DESCRIPTION
some drivers use these keys instead of PreMixEffectClsid and PostMixEffectClsid resolves #13